### PR TITLE
Fix missing dependencies

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -7,7 +7,9 @@ requires 'indirect';
 
 on 'test' => sub {
     requires 'Email::Sender::Transport::Test';
+    requires 'Log::Any::Adapter::TAP';
     requires 'Test::More', '>= 0.98';
+    requires 'Test::Deep';
     requires 'DBI';
     requires 'DBD::SQLite';
 };


### PR DESCRIPTION
This is what's missing from the cpanfile:

- Log::Any::Adapter::TAP
- Test::Deep

I've added them to the test block, hope this is correct.